### PR TITLE
libsbig/handle: dlopen libsbigudrv.so

### DIFF
--- a/config/x_ac_sbigudrv.m4
+++ b/config/x_ac_sbigudrv.m4
@@ -1,6 +1,5 @@
 AC_DEFUN([X_AC_SBIGUDRV], [
   AC_CHECK_HEADER([sbigudrv.h])
   AC_CHECK_HEADER([libsbig/sbigudrv.h],[CFLAGS="${CFLAGS} -I/usr/include/libsbig"])
-  AC_CHECK_LIB([sbigudrv], [SBIGUnivDrvCommand])
   ]
 )

--- a/src/common/libsbig/handle.c
+++ b/src/common/libsbig/handle.c
@@ -48,6 +48,8 @@ sbig_t *sbig_new (void)
 
 int sbig_dlopen (sbig_t *sb, const char *path)
 {
+    if (!path)
+        path = "libsbigudrv.so";
     dlerror ();
     if (!(sb->dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL)))
         return CE_OS_ERROR;

--- a/src/common/libsbig/handle.h
+++ b/src/common/libsbig/handle.h
@@ -5,7 +5,7 @@
  * described in SBIGUdrv sec 3.1.6.
  *
  * Note that if the 'path' argument to sbig_dlopen() may be NULL to indicate
- * that -lsbigudrv was linked in the usual way.
+ * that the system dynamic library search path should be used (see dlopen(2)).
  */
 
 typedef struct sbig sbig_t;


### PR DESCRIPTION
Problem: INDI-packagerd libsbigudrv.so was not
found at runtime on i386 architecture.

The strategy of adding -lsbigudrv to LIBS and then
dlopening NULL and using dlsym to find library paths
was in retrospect fragile.  It worked on arm7l but
does not on i386.

Skip even searching for libsbigudrv.so at configure
time.  If the user doesn't explicitly use sbig -S path,
then dlopen the relative path "libsbigudrv.so" and
let the system search algorithm described in dlopen(3)
find it.