### PR TITLE
libsbig: change default dlopen path

### DIFF
--- a/src/common/libsbig/handle.c
+++ b/src/common/libsbig/handle.c
@@ -49,7 +49,7 @@ sbig_t *sbig_new (void)
 int sbig_dlopen (sbig_t *sb, const char *path)
 {
     if (!path)
-        path = "libsbigudrv.so";
+        path = "libsbigudrv.so.2.1.1";
     dlerror ();
     if (!(sb->dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL)))
         return CE_OS_ERROR;


### PR DESCRIPTION
Problem: dlopen failure when sbig-util is built on
Ubuntu 16.04.3 LTS x86_64 or 17.x i386 with INDI
Ubuntu PPA version of libsbigudrv.so.2.1.1.

It seems that ldconfig links are screwed up for some reason:

$lib/libsbigudrv.so.2.1.1
$lib/libsbigudrv.so -> libsbigudrv.so.2 (missing target).

Rerunning ldconfig did nothing.

To avoid having to use sbig -S libsbigudrv.so.2.1.1 on
every sbig-util command, change the default to that.
It should also work on raspberry pi using the debs provided
by INDI.