### PR TITLE
fix build issues on Ubuntu 18.04 and modern INDI packages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ AC_HEADER_STDC
 # Checks for packages
 ##
 PKG_CHECK_MODULES([LIBUSB], [libusb-1.0], [], [])
+PKG_CHECK_MODULES([CFITSIO], [cfitsio], [], [])
 
 X_AC_SBIGUDRV
 
@@ -60,7 +61,6 @@ AC_CHECK_FUNCS( \
 )
 X_AC_CHECK_COND_LIB(dl, dlerror)
 X_AC_CHECK_COND_LIB(m, sqrt)
-X_AC_CHECK_COND_LIB(cfitsio, ffopen)
 
 ##
 # Epilogue

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -4,7 +4,8 @@ sbigbindir = $(libexecdir)/sbig-util
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
-	-DEXEC_DIR=\"$(sbigbindir)\"
+	-DEXEC_DIR=\"$(sbigbindir)\" \
+	$(CFITSIO_CFLAGS)
 
 bin_PROGRAMS = sbig
 
@@ -20,4 +21,4 @@ LDADD = \
 	$(top_builddir)/src/common/libsbig/libsbig.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libini/libini.la \
-	$(LIBM) $(LIBDL) $(LIBCFITSIO)
+	$(LIBM) $(LIBDL) $(CFITSIO_LIBS)

--- a/src/common/libsbig/handle.c
+++ b/src/common/libsbig/handle.c
@@ -49,7 +49,7 @@ sbig_t *sbig_new (void)
 int sbig_dlopen (sbig_t *sb, const char *path)
 {
     if (!path)
-        path = "libsbigudrv.so.2.1.1";
+        path = "libsbig.so";
     dlerror ();
     if (!(sb->dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL)))
         return CE_OS_ERROR;

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -1,4 +1,7 @@
-AM_CFLAGS = @GCCWARN@
+AM_CFLAGS = \
+	@GCCWARN@ \
+	-Wno-parentheses -Wno-error=parentheses
+
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)


### PR DESCRIPTION
I ran into a few minor problems building sbig-util on my test system.  It seems INDI has renamed the sbigudrv library, compilers have become more pedantic, and I found a build time issue that should have been caught at configure time.